### PR TITLE
chore: add homepage and repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
   "keywords": [
     "react-native"
   ],
+  "bugs": {
+    "url": "https://github.com/hyperjumptech/react-native-confetti"
+  },
+  "homepage": "https://github.com/hyperjumptech/react-native-confetti",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hyperjumptech/react-native-confetti"
+  },
   "author": "Raosan Fikri <raosan@hyperjump.tech>",
   "license": "Apache-2.0",
   "peerDependencies": {},


### PR DESCRIPTION
Point the homepage, repo, and bugs url to this github repo so that it is shown in npm page.